### PR TITLE
Fix SaleItem import in SaleCard

### DIFF
--- a/src/components/sales/SaleCard.tsx
+++ b/src/components/sales/SaleCard.tsx
@@ -1,4 +1,4 @@
-import { Sale } from '@/types';
+import { Sale, SaleItem } from '@/types';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import {


### PR DESCRIPTION
## Summary
- include `SaleItem` type in SaleCard's import

## Testing
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_683fa8121fa08327bb93352a73c92377